### PR TITLE
07-creating-posts.md.erb 다수 수정

### DIFF
--- a/07-creating-posts.md.erb
+++ b/07-creating-posts.md.erb
@@ -473,7 +473,7 @@ Template.postsList.helpers({
   }
 });
 ~~~
-<%= caption "client/views/posts/posts_list.js" %>
+<%= caption "client/templates/posts/posts_list.js" %>
 <%= highlight "3" %>
 
 <%= commit "7-8", "등록일시로 post목록을 정렬한다." %>


### PR DESCRIPTION
1. 오해의 소지가 있는 collections/posts.js를 lib/collections/posts.js로 수정함.
2. 번역이 되었음에도 불구하고 원문이 존재하여 제거함.
3. posts_list.js 파일은 client/views/posts/에 존재합니다.
